### PR TITLE
Fix module routing in RouterFactory

### DIFF
--- a/app/Router/RouterFactory.php
+++ b/app/Router/RouterFactory.php
@@ -15,7 +15,7 @@ final class RouterFactory
 	public static function createRouter(): RouteList
 	{
 		$router = new RouteList;
-		$router->addRoute('<presenter>/<action>', 'Admin:Dashboard:default');
+		$router->addRoute('<module>/<presenter>/<action>', 'Admin:Dashboard:default');
 		return $router;
 	}
 }


### PR DESCRIPTION
Hi,

looks like currently, module routing is broken.
Fixed that by adding `<module>` to the mask.